### PR TITLE
Add PSR-4 entry for Fluid test classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "autoload-dev": {
         "psr-4": {
             "Helhum\\ExtScaffold\\Tests\\": "Tests",
-            "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/core/Tests/"
+            "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/core/Tests/",
+            "TYPO3\\CMS\\Fluid\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/fluid/Tests/"
         }
     },
     "replace": {


### PR DESCRIPTION
The fluid test classes are highly useful as otherwise it is not possible to extend from a class like `\TYPO3\CMS\Fluid\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase`
