### PR TITLE
[TASK] Update the license information in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
             "homepage": "http://helhum.io"
         }
     ],
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "require": {
         "typo3/cms-core": "^7.6.23 || ^8.7.9",
         "typo3/cms-fluid": "^7.6.23 || ^8.7.9",


### PR DESCRIPTION
As of Composer 1.6, "GPL-2.0+" is deprecated and needs to be
replaced with "GPL-2.0-or-later".