### PR TITLE
[BUGFIX] Use the testing framework base test class

### DIFF
--- a/Tests/Unit/FirstClassTest.php
+++ b/Tests/Unit/FirstClassTest.php
@@ -2,7 +2,7 @@
 namespace Helhum\ExtScaffold\Tests\Unit;
 
 use Helhum\ExtScaffold\Tests\Unit\Fixtures\LoadableClass;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 class FirstClassTest extends UnitTestCase
 {


### PR DESCRIPTION
This fixes TYPO3-version-specific "class not found" errors.