### PR TITLE
[CLEANUP] Move TYPO3_PATH_ROOT to the env section in the .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ matrix:
       env: TYPO3_VERSION="^8.7"
 
 env:
-  - TYPO3_VERSION="^7.6"
-  - TYPO3_VERSION="^8.7"
+  global:
+    - TYPO3_PATH_ROOT=$PWD/.Build/public
+  matrix:
+    - TYPO3_VERSION="^7.6"
+    - TYPO3_VERSION="^8.7"
 
 sudo: false
 
@@ -29,7 +32,6 @@ cache:
 install:
   - composer require-typo3-version "$TYPO3_VERSION"
   - git checkout .
-  - export TYPO3_PATH_ROOT=$PWD/.Build/public
 
 script:
   - >


### PR DESCRIPTION
Global environment variables belong in the env/global section instead of
getting set in a build step.