### PR TITLE
[TASK] Set a minimum PHP version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "license": "GPL-2.0-or-later",
     "require": {
+        "php": "^5.5 || ~7.0 || ~7.1 || ~7.2",
         "typo3/cms-core": "^7.6.23 || ^8.7.9",
         "typo3/cms-fluid": "^7.6.23 || ^8.7.9",
         "typo3/cms-frontend": "^7.6.23 || ^8.7.9"


### PR DESCRIPTION
This allows IDEs like PhpStorm to automatically determine the PHP
language level.