### PR TITLE
[TASK] Use getFrontendResponse from the functional base test case

### DIFF
--- a/Tests/Functional/RenderingTest.php
+++ b/Tests/Functional/RenderingTest.php
@@ -59,59 +59,7 @@ class RenderingTest extends FunctionalTestCase
      */
     public function emailViewHelperWorksWithSpamProtection()
     {
-        $requestArguments = array('id' => '1');
         $expectedContent = '<a href="javascript:linkTo_UnCryptMailto(\'ocknvq,kphqBjgnjwo0kq\');">info(AT)helhum(DOT)io</a>' . chr(10);
-        $this->assertSame($expectedContent, $this->fetchFrontendResponse($requestArguments)->getContent());
-    }
-
-
-
-    /* ***************
-     * Utility methods
-     * ***************/
-
-
-
-    /**
-     * @param array $requestArguments
-     * @param bool $failOnFailure
-     * @return Response
-     */
-    protected function fetchFrontendResponse(array $requestArguments, $failOnFailure = true)
-    {
-        if (!empty($requestArguments['url'])) {
-            $requestUrl = '/' . ltrim($requestArguments['url'], '/');
-        } else {
-            $requestUrl = '/?' . GeneralUtility::implodeArrayForUrl('', $requestArguments);
-        }
-
-        $arguments = array(
-            'documentRoot' => $this->getInstancePath(),
-            'requestUrl' => $requestUrl,
-        );
-
-        $template = new \Text_Template('ntf://Frontend/Request.tpl');
-        $template->setVar(
-            array(
-                'arguments' => var_export($arguments, true),
-                'originalRoot' => ORIGINAL_ROOT,
-                'ntfRoot' => __DIR__ . '/../../.Build/vendor/nimut/testing-framework/',
-            )
-        );
-
-        $php = AbstractPhpProcess::factory();
-        $response = $php->runJob($template->render());
-        $result = json_decode($response['stdout'], true);
-
-        if ($result === null) {
-            $this->fail('Frontend Response is empty');
-        }
-
-        if ($failOnFailure && $result['status'] === Response::STATUS_Failure) {
-            $this->fail('Frontend Response has failure:' . LF . $result['error']);
-        }
-
-        $response = new Response($result['status'], $result['content'], $result['error']);
-        return $response;
+        $this->assertSame($expectedContent, $this->getFrontendResponse(1)->getContent());
     }
 }


### PR DESCRIPTION
This allows the removal of a utility method from the example test case.