### PR TITLE
[TASK] Make setUp protected

### DIFF
--- a/Tests/Functional/RenderingTest.php
+++ b/Tests/Functional/RenderingTest.php
@@ -47,7 +47,7 @@ class RenderingTest extends FunctionalTestCase
      */
     protected $coreExtensionsToLoad = array('fluid');
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->importDataSet(__DIR__ . '/Fixtures/Database/pages.xml');


### PR DESCRIPTION
The method is protected in the parent class, and it does not need to
be public.