### PR TITLE
[TASK] Remove the TYPO3_PATH_ROOT settings from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ cache:
 install:
   - composer require-typo3-version "$TYPO3_VERSION"
   - git checkout .
-  - export TYPO3_PATH_ROOT=$PWD/.Build/public
 
 script:
   - >


### PR DESCRIPTION
This environment variable is not needed anymore.